### PR TITLE
Implemented error handler

### DIFF
--- a/alumnusb_system/settings.py
+++ b/alumnusb_system/settings.py
@@ -64,6 +64,7 @@ REST_FRAMEWORK = {
         'rest_framework.authentication.SessionAuthentication',
         'rest_framework.authentication.BasicAuthentication',
     ),
+    'EXCEPTION_HANDLER': 'alumnusb_system.utils.custom_exception_handler',
 }
 
 JWT_AUTH = {
@@ -148,7 +149,7 @@ AUTH_PASSWORD_VALIDATORS = [
 # Internationalization
 # https://docs.djangoproject.com/en/3.0/topics/i18n/
 
-LANGUAGE_CODE = 'en-us'
+LANGUAGE_CODE = 'es-mx'
 
 TIME_ZONE = 'UTC'
 

--- a/alumnusb_system/utils.py
+++ b/alumnusb_system/utils.py
@@ -1,0 +1,37 @@
+from rest_framework.views import exception_handler
+from rest_framework.exceptions import ValidationError
+
+
+def custom_exception_handler(exc, context):
+    # Call REST framework's default exception handler first,
+    # to get the standard error response.
+    exception = exception_handler(exc, context)
+    # Now add the HTTP status code to the response.
+    errors = exception.data
+    list_errors = []
+    for key,value in errors.items():
+      print(key,value)
+      if hasattr(value[0],'code'):
+        if value[0].code == 'required':
+          list_errors.append('El campo {} es requerido'.format(key))
+        if value[0].code == 'blank':
+          list_errors.append('El campo {} no puede estar en blanco'.format(key))
+        if value[0].code == 'unique':
+          if key == 'username': # Ver si se puede cambiar este mensaje de error en otra parte del codigo
+            list_errors.append('Ya existe un usuario con este username')
+          else:
+            list_errors.append(value[0])
+        if value[0].code == 'null':
+          list_errors.append('El campo {} no puede ser nulo'.format(key))
+        if value[0].code == 'max_length':
+          list_errors.append('{}: {}'.format(key,value[0]))
+        if value[0].code == 'invalid_choice':
+          list_errors.append('{} para el campo {}'.format(value[0][:-1],key))
+      else:
+          list_errors.append(value)
+    response = {
+      'status_code' : exception.status_code,
+      'error' : list_errors
+    }
+    exception.data = response
+    return exception

--- a/api/CSV/views.py
+++ b/api/CSV/views.py
@@ -20,12 +20,12 @@ def upload_csv_file(request):
   Json with the result of operation
   """
   if 'file' not in request.FILES:
-    return JsonResponse({'status': 400, 'error': 'El campo file es requerido'}, status=status.HTTP_400_BAD_REQUEST)
+    return JsonResponse({'status_code': 400, 'error': 'El campo file es requerido'}, status=status.HTTP_400_BAD_REQUEST)
   
   csv_file = request.FILES['file']
 
   if not csv_file.name.endswith('.csv'):
-    return JsonResponse({'status': 400, 'error': 'El formato del archivo no es .csv'}, status=status.HTTP_400_BAD_REQUEST)
+    return JsonResponse({'status_code': 400, 'error': 'El formato del archivo no es .csv'}, status=status.HTTP_400_BAD_REQUEST)
 
   try:
     data_set = csv_file.read().decode('UTF-8')
@@ -36,7 +36,7 @@ def upload_csv_file(request):
 
       if (len(column) != 34):
         error = 'Formato incorrecto de CSV'
-        return JsonResponse({'status': 400, 'error': error}, status=status.HTTP_400_BAD_REQUEST)
+        return JsonResponse({'status_code': 400, 'error': error}, status=status.HTTP_400_BAD_REQUEST)
 
       UserInformation.objects.filter(email=column[9]).delete()
       UserStats.objects.filter(email=column[9]).delete()
@@ -81,7 +81,7 @@ def upload_csv_file(request):
     return JsonResponse({'status': 200, 'message': 'La carga fue exitosa'}, status=status.HTTP_200_OK)
 
   except: 
-    return JsonResponse({'status': 400, 'message': 'El formato del archivo no es correcto'}, status=status.HTTP_400_BAD_REQUEST)
+    return JsonResponse({'status_code': 400, 'message': 'El formato del archivo no es correcto'}, status=status.HTTP_400_BAD_REQUEST)
 
 ## Functions to help the csv loader
 def is_int(x):

--- a/api/accounts/serializers.py
+++ b/api/accounts/serializers.py
@@ -22,7 +22,8 @@ class UserSerializer(serializers.ModelSerializer):
  
     class Meta:
         model = User
-        fields = ('id', 'username', 'email', 'password')   
+        fields = ('id', 'username', 'email', 'password')
+        extra_kwargs = {'username': {'required': True}, 'email': {'required': True}, 'password': {'required': True}}   
  
 class UserInformationSerializer(serializers.ModelSerializer):
     class Meta:

--- a/api/accounts/utils.py
+++ b/api/accounts/utils.py
@@ -3,8 +3,8 @@ from enum import Enum
 
 # THIS SECTION IS USEFUL TO SAVE ERROR MSGS 
 class ErrorMessages:
-    UserNotFound = {"error" : "User does not exist"}
-    UnauthAccesAccount = {"error" : "Unauthorized access to another user's account"}
+    UserNotFound = {"error" : ["User does not exist"], "status_code": 404}
+    UnauthAccesAccount = {"error" : ["Unauthorized access to another user's account"], "status_code": 401}
 
 # THIS SECTION IS USEFUL TO ADMINISTRATE TYPES OF ACHIEVEMENTS
 class AchievementsData:

--- a/api/accounts/views.py
+++ b/api/accounts/views.py
@@ -9,6 +9,7 @@ from rest_framework import status
 from .serializers import UserSerializer, UserInformationSerializer, UserStatsSerializer, UserAchievementsSerializer
 from .utils import ErrorMessages, defaultUserStats, defaultUserInfo, AchievementsDic, AchievementsType
 from datetime import date
+from rest_framework.exceptions import ValidationError
 
 @api_view(['POST'])
 @authentication_classes([])
@@ -31,7 +32,7 @@ def register(request):
 
     # Check if the body of the request was correct
     if not user_serializer.is_valid():
-        return JsonResponse(user_serializer.errors, status=status.HTTP_400_BAD_REQUEST) 
+        raise ValidationError(user_serializer.errors)
 
     email = form_content['email']
     user_serializer.save()
@@ -259,7 +260,7 @@ class Profile(APIView):
 
         # Check for errors in the form 
         if not user_info_serial.is_valid():
-            return JsonResponse(user_info_serial.errors, status=status.HTTP_400_BAD_REQUEST)
+           raise ValidationError(user_info_serial.errors)
         
         user_info_serial.save()
 


### PR DESCRIPTION
Con esto, quedaria implementado un manejo de errores mas tratable para frontend:

- Se hizo un custom_exception_handler para que devuelva un JSON de la forma 
  `{"status_code": codigo_de_la_respuesta, "error": [arreglo de strings de errores]}`

- Se modifico algunos endpoints para que en vez de que lanzaran un JSON con los errores del Serializer, lanzaran un ValidationError y asi llegara al custom_exception_handler

- Se modifico el registro para que los campos fueran requeridos

- Se modificaron algunos errores que ya existian para que estuviesen con el nuevo formato

------CONSIDERACIONES------

- Si se agrega alguna validacion de campo en algun Field de Modelo o de Serializer, este caso se tiene que agregar al  custom_exception_handler

- El login no pude capturar el error, presiento que habria que crear un login desde 0